### PR TITLE
Remove batch size constraint

### DIFF
--- a/src/main/java/com/example/cockroachdemo/service/MyBatisAccountService.java
+++ b/src/main/java/com/example/cockroachdemo/service/MyBatisAccountService.java
@@ -26,7 +26,7 @@ public class MyBatisAccountService implements AccountService {
     private Random random = new Random();
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public void createAccountsTable() {
         mapper.createAccountsTable();
     }
@@ -77,25 +77,25 @@ public class MyBatisAccountService implements AccountService {
     }
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public Optional<Account> getAccount(int id) {
         return mapper.findAccountById(id);
     }
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public int transferFunds(int fromId, int toId, int amount) {
         return mapper.transfer(fromId, toId, amount);
     }
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public long findCountOfAccounts() {
         return mapper.findCountOfAccounts();
     }
 
     @Override
-    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @Transactional
     public int deleteAllAccounts() {
         return mapper.deleteAllAccounts();
     }

--- a/src/main/java/com/example/cockroachdemo/service/MyBatisAccountService.java
+++ b/src/main/java/com/example/cockroachdemo/service/MyBatisAccountService.java
@@ -26,7 +26,7 @@ public class MyBatisAccountService implements AccountService {
     private Random random = new Random();
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public void createAccountsTable() {
         mapper.createAccountsTable();
     }
@@ -52,7 +52,6 @@ public class MyBatisAccountService implements AccountService {
     @Override
     @Transactional(propagation = Propagation.REQUIRES_NEW)
     public BatchResults bulkInsertRandomAccountData(int numberToInsert) {
-        int BATCH_SIZE = 128;
         List<List<BatchResult>> results = new ArrayList<>();
 
         for (int i = 0; i < numberToInsert; i++) {
@@ -60,13 +59,10 @@ public class MyBatisAccountService implements AccountService {
             account.setId(random.nextInt(1000000000));
             account.setBalance(random.nextInt(1000000000));
             batchMapper.insertAccount(account);
-            if ((i + 1) % BATCH_SIZE == 0) {
-                results.add(batchMapper.flush());
-            }
         }
-        if(numberToInsert % BATCH_SIZE != 0) {
-            results.add(batchMapper.flush());
-        }
+
+        results.add(batchMapper.flush());
+
         return new BatchResults(results.size(), calculateRowsAffectedByMultipleBatches(results));
     }
 
@@ -77,25 +73,25 @@ public class MyBatisAccountService implements AccountService {
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public Optional<Account> getAccount(int id) {
         return mapper.findAccountById(id);
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public int transferFunds(int fromId, int toId, int amount) {
         return mapper.transfer(fromId, toId, amount);
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public long findCountOfAccounts() {
         return mapper.findCountOfAccounts();
     }
 
     @Override
-    @Transactional
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
     public int deleteAllAccounts() {
         return mapper.deleteAllAccounts();
     }


### PR DESCRIPTION
@jeffgbutler 
In https://github.com/cockroachdb/docs/pull/7498#issuecomment-659446603, you wrote

>JDBC batch can get complex, so it might not be worth mentioning this. But the batch methods in this example do intermediate commits - that's why there is weird logic around the batch size of 128. If you don't want to do intermediate commits it can be simplified substantially. But I also think I remember reading somewhere that Cockroach likes batch sizes that are powers of 2?

After looking into this more, I believe I was wrong about the batch size recommendation extending beyond our JDBC compatibility to other ORMs. I think this PR removes the batch size constraint and intermediate commit logic. Please let me know if that's not the case.

Thanks!